### PR TITLE
Listen to rabbitMQ queue, execute php script on message

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,10 @@
+COLOR=green
+
+RABBITMQ_HOST=rabbitmq
+RABBITMQ_PORT=5672
+RABBITMQ_USER=guest
+RABBITMQ_PASS=guest
+
+RABBITMQ_EXCHANGE=orders
+
+ROBOT_SCRIPTS_DIR=/var/robot-scripts

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+composer.lock
+vendor/
+docker-compose.override.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM sergeytykhonov/rpi-php:7-alpine
+
+RUN	apk update && \
+	apk upgrade && \
+	apk add --update curl openssl && \
+	curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && \
+	chmod +x /usr/local/bin/composer && \
+	apk del curl openssl && \
+	rm -rf /var/cache/apk/*
+
+RUN docker-php-ext-install bcmath

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+all:
+	docker-compose up -d --no-deps slave-php
+
+	docker exec -ti slave-php /bin/sh -c "composer install"
+
+	docker-compose up -d
+
+bash:
+	docker exec -ti slave-php /bin/sh

--- a/README.md
+++ b/README.md
@@ -1,5 +1,45 @@
 Drop fleet control slave
 ========================
 
-Service on Raspberry that listens to master orders,
-and execute them by calling robot move script.
+Service running on Raspberry that listens for master orders,
+and execute them by calling robot move scripts.
+
+
+## Install
+
+Requires on the Raspberry Pi:
+
+ - git, docker, docker-compose
+ - folder with 4 php scripts `forward.php`, `backward.php`, `right.php`, `left.php`
+
+Fetch this repo:
+
+``` bash
+git clone https://github.com/alcalyn/drop-fleetcontrol-slave.git
+cd drop-fleetcontrol-slave/
+```
+
+Configure in `.env` file:
+
+```
+# Your Raspberry unique name
+COLOR=green
+
+# Your RabbitMq host and exchange name
+RABBITMQ_HOST=rabbitmq
+RABBITMQ_PORT=5672
+RABBITMQ_USER=guest
+RABBITMQ_PASS=guest
+
+RABBITMQ_EXCHANGE=orders
+
+# Path to your scripts (let it as is if running in docker)
+ROBOT_SCRIPTS_DIR=/var/robot-scripts
+```
+
+
+Install and run the service:
+
+``` bash
+make
+```

--- a/bin/check-rabbitmq.php
+++ b/bin/check-rabbitmq.php
@@ -1,0 +1,24 @@
+<?php
+
+require_once __DIR__.'/../vendor/autoload.php';
+
+use PhpAmqpLib\Connection\AMQPStreamConnection;
+
+try {
+    $connection = new AMQPStreamConnection(
+        getenv('RABBITMQ_HOST'),
+        getenv('RABBITMQ_PORT'),
+        getenv('RABBITMQ_USER'),
+        getenv('RABBITMQ_PASS')
+    );
+
+    $connection->close();
+
+    echo 'RabbitMQ ON'.PHP_EOL;
+
+    exit(0);
+} catch (\ErrorException $e) {
+    echo 'RabbitMQ OFF'.PHP_EOL;
+
+    exit(1);
+}

--- a/bin/execute-orders.php
+++ b/bin/execute-orders.php
@@ -1,0 +1,21 @@
+<?php
+
+require_once __DIR__.'/../vendor/autoload.php';
+
+use PhpAmqpLib\Connection\AMQPStreamConnection;
+use Drop\FleetControl\RobotApi;
+use Drop\FleetControl\Application;
+
+$connection = new AMQPStreamConnection(
+    getenv('RABBITMQ_HOST'),
+    getenv('RABBITMQ_PORT'),
+    getenv('RABBITMQ_USER'),
+    getenv('RABBITMQ_PASS')
+);
+
+$robotApi = new RobotApi(getenv('ROBOT_SCRIPTS_DIR'));
+$application = new Application($connection, getenv('COLOR'), getenv('RABBITMQ_EXCHANGE'), $robotApi);
+
+echo 'listening rabbitmq message from queue ', getenv('COLOR'), PHP_EOL;
+
+$application->executeOrders();

--- a/bin/wait-for-it.sh
+++ b/bin/wait-for-it.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+until php `dirname $0`/check-rabbitmq.php > /dev/null
+do
+    echo 'Waiting for RabbitMQ starting...'
+    sleep 1
+done
+
+echo 'RabbitMQ is now running.'
+
+echo 'Running next command:'
+echo "$@"
+
+exec "$@"

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,10 @@
+{
+    "require": {
+        "php-amqplib/php-amqplib": ">=2.6.1"
+    },
+    "autoload": {
+        "psr-4": {
+            "Drop\\FleetControl\\": "src/"
+        }
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '2'
+
+services:
+    fleet-control-slave:
+        build: .
+        env_file: .env
+        volumes:
+            - /sys:/sys
+            - .:/var/www/html
+            - ../robot-scripts/:/var/robot-scripts
+        working_dir: /var/www/html
+        command: ["./bin/wait-for-it.sh", "php", "bin/execute-orders.php"]
+
+    slave-php:
+        build: .
+        container_name: slave-php
+        env_file: .env
+        volumes:
+            - /sys:/sys
+            - .:/var/www/html
+            - ../robot-scripts/:/var/robot-scripts
+        working_dir: /var/www/html
+        command: sleep 100000000

--- a/src/Application.php
+++ b/src/Application.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Drop\FleetControl;
+
+use PhpAmqpLib\Connection\AMQPStreamConnection;
+
+class Application
+{
+    /**
+     * @var AMQPStreamConnection
+     */
+    private $connection;
+
+    /**
+     * @var string
+     */
+    private $color;
+
+    /**
+     * @var string
+     */
+    private $exchangeName;
+
+    /**
+     * @var RobotApi
+     */
+    private $robotApi;
+
+    /**
+     *
+     * @param AMQPStreamConnection $connection
+     * @param string $color
+     * @param string $exchangeName
+     * @param RobotApi $robotApi
+     */
+    public function __construct(AMQPStreamConnection $connection, $color, $exchangeName, RobotApi $robotApi)
+    {
+        $this->connection = $connection;
+        $this->color = $color;
+        $this->exchangeName = $exchangeName;
+        $this->robotApi = $robotApi;
+    }
+
+    /**
+     * Listens to RabbitMQ messages and execute orders on receive.
+     */
+    public function executeOrders()
+    {
+        $channel = $this->connection->channel();
+
+        $channel->exchange_declare($this->exchangeName, 'direct');
+
+        list($queueName, ,) = $channel->queue_declare($this->color, false, false, true, false);
+
+        $channel->queue_bind($queueName, $this->exchangeName, $this->color);
+
+        $callback = function ($message) {
+            try {
+                echo $this->robotApi->executeOrder($message->body), PHP_EOL;
+            } catch (\RuntimeException $e) {
+                echo $e->getMessage(), PHP_EOL;
+            }
+        };
+
+        $channel->basic_consume($queueName, '', false, true, false, false, $callback);
+
+        while (count($channel->callbacks)) {
+            $channel->wait();
+        }
+
+        $channel->close();
+        $this->connection->close();
+    }
+}

--- a/src/RobotApi.php
+++ b/src/RobotApi.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Drop\FleetControl;
+
+class RobotApi
+{
+    /**
+     * @var string
+     */
+    private $scriptsDir;
+
+    /**
+     * @param string $scriptsDir
+     */
+    public function __construct($scriptsDir)
+    {
+        $this->scriptsDir = $scriptsDir;
+    }
+
+    /**
+     * @param string $order
+     *
+     * @return string result of script.
+     *
+     * @throws \RuntimeException when order not available.
+     */
+    public function executeOrder($order)
+    {
+        $availableOrders = [
+            'forward',
+            'backward',
+            'right',
+            'left',
+        ];
+
+        if (!in_array($order, $availableOrders)) {
+            throw new \RuntimeException('Order not available: "'.$order.'"');
+        }
+
+        return shell_exec("php {$this->scriptsDir}/$order.php");
+    }
+}


### PR DESCRIPTION
This service will be run on a Raspberry, it should listen message for a RabbitMQ queue, and execute a php script on message.

### Install

on Raspberry:

- Needs git, docker and docker-compose.
- In another directory (i.e `./robot-scripts/`), create 4 php scripts `forward.php`, `backward.php`, `right.php`, `left.php` filled with something like `<?php echo __FILE__;`
- Clone this branch
``` bash
git clone https://github.com/alcalyn/drop-fleetcontrol-slave.git --branch=feature/execute-rabbitmq-orders
cd drop-fleetcontrol-slave/
```

- Create a `docker-compose.override.yml` in project root to override with these dev services:

``` yml
version: '2'

services:
    # host your own rabbitmq on raspberry to test
    rabbitmq:
        image: mathewdgardner/rabbitmq:management-alpine-arm
        ports:
            - 15672:15672

    # link Raspberry container to this rabbitmq host
    fleet-control-slave:
        links:
            - rabbitmq
```

- Then install and run the project:

``` bash
make
```

### Test

- Display container logs

``` bash
docker-compose logs -ft
```

- Access to RabbitMq UI on `http://raspberry-ip:15672` (`guest` / `guest`)

- Then try to send a message to the `orders` exchange with `green` as routing key (or the color set in `.env` file), and a message like `forward`, `right`, ...

=> You should see the logs from php scripts you created (`forward.php`, `backward.php`, ...).
